### PR TITLE
chore: Update "Error return value of" rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,7 +74,7 @@ issues:
   exclude:
     # errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
     - Error return value of
-      .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv).
+      .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv|.*Disconnect).
       is not checked
 
     # golint: Exported variables are rarely used and generally reserved for errors which should be self explanitory


### PR DESCRIPTION
Added `*.Disconnect` to the "Error return value of" rules, as mongo driver doesn't use `.Close`, but `.Disconnect` (https://github.com/mongodb/mongo-go-driver/blob/d92bcdb574816fe84a7924b3394c4eef1fc1a54e/mongo/client.go#L121)