### PR TITLE
Use bash and enable pipefail option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -eo pipefail -c
 
 ifeq ("$(wildcard project)","")
 $(error project directory doesn't exist)


### PR DESCRIPTION
Exit status of the last command is used by default.

This was causing install steps to be treated as successful, even though they weren't - see `make install` of https://circleci.com/gh/utilitywarehouse/partner-bb-points/113 for example